### PR TITLE
Feature/conversion operations2

### DIFF
--- a/example/source/OldInstrTest.cpp
+++ b/example/source/OldInstrTest.cpp
@@ -17,6 +17,11 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 
 	module.addCapability(spv::Capability::Shader);
 	module.addCapability(spv::Capability::VulkanMemoryModelKHR);
+	module.addCapability(spv::Capability::Float16);
+	module.addCapability(spv::Capability::Float64);
+	module.addCapability(spv::Capability::Int16);
+	module.addCapability(spv::Capability::Int64);
+
 	module.addExtension("SPV_KHR_vulkan_memory_model");
 	Instruction* ext = module.getExtensionInstructionImport("GLSL.std.450");
 	module.setMemoryModel(spv::AddressingModel::Logical, spv::MemoryModel::VulkanKHR);
@@ -70,6 +75,9 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 		bb->opConvertFToS(cross);
 		bb->opConvertFToU(dot);
 
+		Instruction* f64 = bb->opFConvert(dot, 64u);
+		Instruction* f16 = bb->opFConvert(dot, 16u);
+
 		cross = bb->opVectorTimesScalar(cross, fNeg);
 
 		Instruction* mat3 = bb->opOuterProduct(uniVec, uniVec);
@@ -81,6 +89,8 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 		index = bb->opLoad(index);
 
 		Instruction* uInt = module.constant(22u);
+		Instruction* uInt64 = bb->opUConvert(uInt, 64u); // zero extend
+		Instruction* uInt16 = bb->opUConvert(uInt, 16u);
 
 		bb->opConvertUToF(uInt);
 
@@ -93,6 +103,9 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 		sNeg = bb->opIMul(sNeg, index);
 		sNeg = bb->opSMod(sNeg, index);
 		sNeg = bb->opSDiv(uInt, sNeg);
+
+		Instruction* s64 = bb->opSConvert(sNeg, 64u);
+		Instruction* s16 = bb->opSConvert(sNeg, 16u);
 
 		// generic
 		bb->Add(sNeg, uInt);

--- a/example/source/OldInstrTest.cpp
+++ b/example/source/OldInstrTest.cpp
@@ -61,6 +61,7 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 		z = bb.ext<GLSL>()->opRound(z);
 
 		Instruction* uniVec = bb->opLoad(uniformVar);
+		bb->bitcast<vector_t<int, 3>>(uniVec);
 
 		Instruction* cross = bb.ext<GLSL>()->opCross(uniVec, uniVec);
 		Instruction* dot = bb->opDot(cross, uniVec);
@@ -92,6 +93,8 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 		Instruction* uInt = module.constant(22u);
 		Instruction* uInt64 = bb->opUConvert(uInt, 64u); // zero extend
 		Instruction* uInt16 = bb->opUConvert(uInt, 16u);
+
+		bb->bitcast<double>(uInt64);
 
 		bb->opConvertUToF(uInt);
 

--- a/example/source/OldInstrTest.cpp
+++ b/example/source/OldInstrTest.cpp
@@ -77,6 +77,7 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 
 		Instruction* f64 = bb->opFConvert(dot, 64u);
 		Instruction* f16 = bb->opFConvert(dot, 16u);
+		Instruction* q16 = bb->opQuantizeToF16(dot);
 
 		cross = bb->opVectorTimesScalar(cross, fNeg);
 

--- a/lib/include/spvgentwo/HashMapIterator.h
+++ b/lib/include/spvgentwo/HashMapIterator.h
@@ -8,7 +8,7 @@ namespace spvgentwo
 	template <class Key, class Value>
 	struct NodeT
 	{
-		template <class Key, class Value>
+		template <class K, class V>
 		friend class HashMap;
 
 		template <class ...Args>

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -481,6 +481,13 @@ namespace spvgentwo
 
 		Instruction* opConvertUToF(Instruction* _pUIntVec) { return scalarVecOp(spv::Op::OpConvertUToF, _pUIntVec, nullptr, "Operand of OpConvertUToF is not a scalar or vector of int type"); }
 
+		// convert scalar or vector to different componenet bit width
+		Instruction* opUConvert(Instruction* _pUIntVec, unsigned int _bitWidth);
+
+		Instruction* opSConvert(Instruction* _pSIntVec, unsigned int _bitWidth);
+
+		Instruction* opFConvert(Instruction* _pFloatVec, unsigned int _bitWidth);
+
 	private:
 
 		// creates literals

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -492,6 +492,11 @@ namespace spvgentwo
 
 		Instruction* opConvertPtrToU(Instruction* _pPhysPtr, unsigned int _bitWidth);
 
+		Instruction* opBitcast(Instruction* _pResultType, Instruction* _pOperand);
+
+		template<class T> // generic version of opBitcast, generates spv type from T
+		Instruction* bitcast(Instruction* _pOperand);
+
 	private:
 
 		// creates literals
@@ -554,6 +559,12 @@ namespace spvgentwo
 		return this;
 	}
 	
+	template<class T>
+	inline Instruction* Instruction::bitcast(Instruction* _pOperand)
+	{
+		return opBitcast(getModule()->type<T>(), _pOperand);
+	}
+
 	template<class T, class ...Args>
 	inline void Instruction::makeOpInternal(T _first, Args ..._args)
 	{

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -488,6 +488,8 @@ namespace spvgentwo
 
 		Instruction* opFConvert(Instruction* _pFloatVec, unsigned int _bitWidth);
 
+		Instruction* opQuantizeToF16(Instruction* _pFloatVec);
+
 	private:
 
 		// creates literals

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -490,6 +490,8 @@ namespace spvgentwo
 
 		Instruction* opQuantizeToF16(Instruction* _pFloatVec);
 
+		Instruction* opConvertPtrToU(Instruction* _pPhysPtr, unsigned int _bitWidth);
+
 	private:
 
 		// creates literals

--- a/lib/include/spvgentwo/Type.h
+++ b/lib/include/spvgentwo/Type.h
@@ -317,7 +317,7 @@ namespace spvgentwo
 		bool isVectorOfSInt(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfInt(_length, _componentWidth, Sign::Signed); }
 		bool isVectorOfUInt(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfInt(_length, _componentWidth, Sign::Unsigned); }
 		bool isVectorOfFloat(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfLength(_length, _componentWidth) && front().isFloat(); }
-		bool isVectorOfBool(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfLength(_length, _componentWidth) && front().isBool(); }
+		bool isVectorOfBool(const unsigned int _length = 0u) const { return isVectorOfLength(_length) && front().isBool(); }
 
 		bool isScalarOrVectorOf(const spv::Op _type, const unsigned int _length = 0u, const unsigned int _componentWidth = 0u, Sign _sign = Sign::Any) const { return (m_Type == _type && (_componentWidth == 0u || m_IntWidth == _componentWidth) && hasSign(_sign)) || isVectorOf(_type, _length, _componentWidth, _sign); }
 		bool isNumericalScalarOrVector(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u, Sign _sign = Sign::Any) const { return (isNumerial() && (_componentWidth == 0u || m_IntWidth == _componentWidth) && hasSign(_sign)) || (isVectorOfLength(_length, _componentWidth, _sign) && front().isNumerial()); }

--- a/lib/include/spvgentwo/Type.h
+++ b/lib/include/spvgentwo/Type.h
@@ -288,7 +288,8 @@ namespace spvgentwo
 		bool isF32() const { return m_Type == spv::Op::OpTypeFloat && m_FloatWidth == 32u; }
 		bool isF64() const { return m_Type == spv::Op::OpTypeFloat && m_FloatWidth == 64u; }
 
-		bool isScalar() const { return isInt() || isFloat(); }
+		bool isNumerial() const { return isInt() || isFloat(); }
+		bool isScalar() const { return isNumerial() || isBool(); }
 		bool isAggregate() const { return isStruct() || isArray(); }
 		bool isComposite() const { return isAggregate() || isMatrix() || isVector(); }
 
@@ -311,14 +312,16 @@ namespace spvgentwo
 		bool isVectorOf(const spv::Op _type, const unsigned int _length = 0u, const unsigned int _componentWidth = 0u, Sign _sign = Sign::Any) const { return isVector() && front().getType() == _type && (_length == 0u || m_VecComponentCount == _length) && (_componentWidth == 0u || front().getIntWidth() == _componentWidth) && front().hasSign(_sign); }
 
 		// does not check for type
-		bool isVectorOfLength(const unsigned int _length, const unsigned int _componentWidth = 0u) const { return isVector() && (_length == 0u || m_VecComponentCount == _length) && (_componentWidth == 0u || front().getIntWidth() == _componentWidth); }
-		bool isVectorOfInt(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfLength(_length, _componentWidth) && front().isInt(); }
-		bool isVectorOfSInt(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfLength(_length, _componentWidth) && front().isSInt(); }
-		bool isVectorOfUInt(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfLength(_length, _componentWidth) && front().isUInt(); }
+		bool isVectorOfLength(const unsigned int _length, const unsigned int _componentWidth = 0u, Sign _sign = Sign::Any) const { return isVector() && front().hasSign(_sign) && (_length == 0u || m_VecComponentCount == _length) && (_componentWidth == 0u || front().getIntWidth() == _componentWidth); }
+		bool isVectorOfInt(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u, Sign _sign = Sign::Any) const { return isVectorOfLength(_length, _componentWidth, _sign) && front().isInt(); }
+		bool isVectorOfSInt(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfInt(_length, _componentWidth, Sign::Signed); }
+		bool isVectorOfUInt(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfInt(_length, _componentWidth, Sign::Unsigned); }
 		bool isVectorOfFloat(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfLength(_length, _componentWidth) && front().isFloat(); }
 		bool isVectorOfBool(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u) const { return isVectorOfLength(_length, _componentWidth) && front().isBool(); }
 
 		bool isScalarOrVectorOf(const spv::Op _type, const unsigned int _length = 0u, const unsigned int _componentWidth = 0u, Sign _sign = Sign::Any) const { return (m_Type == _type && (_componentWidth == 0u || m_IntWidth == _componentWidth) && hasSign(_sign)) || isVectorOf(_type, _length, _componentWidth, _sign); }
+		bool isNumericalScalarOrVector(const unsigned int _length = 0u, const unsigned int _componentWidth = 0u, Sign _sign = Sign::Any) const { return (isNumerial() && (_componentWidth == 0u || m_IntWidth == _componentWidth) && hasSign(_sign)) || (isVectorOfLength(_length, _componentWidth, _sign) && front().isNumerial()); }
+
 		bool hasSameVectorLength(const Type& _other) const { return isVector() && _other.isVector() && m_VecComponentCount == _other.m_VecComponentCount; }
 		bool hasSameVectorLength(const Type& _other, const spv::Op _componentType) const { return isVectorOf(_componentType) && _other.isVectorOf(_componentType) && m_VecComponentCount == _other.m_VecComponentCount; }
 		bool isScalarOrVectorOfSameLength(const spv::Op _type, const Type& _other, bool _sameComponentWidth = true) const { return (!_sameComponentWidth || getBaseType().getIntWidth() == _other.getBaseType().getIntWidth()) && (hasSameVectorLength(_other, _type) || (m_Type == _type && _other.m_Type == _type && isScalar() && _other.isScalar())); }

--- a/lib/include/spvgentwo/Vector.h
+++ b/lib/include/spvgentwo/Vector.h
@@ -253,14 +253,14 @@ namespace spvgentwo
 				return false;
 			}
 
-			if (_pInitValue != nullptr)
+			if (_pInitValue == nullptr)
 			{
 				for (size_t i = m_elements; i < m_capacity; ++i)
 				{
 					new(m_pData + i) T{};
 				}
 			}
-			else //if constexpr(stdrep::is_constructible_v<T, const T&>)
+			else if constexpr(stdrep::is_constructible_v<T, const T&>)
 			{
 				for (size_t i = m_elements; i < m_capacity; ++i)
 				{

--- a/lib/include/spvgentwo/stdreplacement.h
+++ b/lib/include/spvgentwo/stdreplacement.h
@@ -200,18 +200,18 @@ namespace spvgentwo::stdrep
 // custom traits
 namespace spvgentwo::traits
 {
-	template <class T> constexpr bool is_primitive_type_v = false;
-	template <>	constexpr bool is_primitive_type_v<bool> = true;
-	template <>	constexpr bool is_primitive_type_v<short> = true;
-	template <>	constexpr bool is_primitive_type_v<unsigned short> = true;
-	template <>	constexpr bool is_primitive_type_v<int> = true;
-	template <>	constexpr bool is_primitive_type_v<unsigned int> = true;
-	template <>	constexpr bool is_primitive_type_v<long> = true;
-	template <>	constexpr bool is_primitive_type_v<unsigned long> = true;
-	template <>	constexpr bool is_primitive_type_v<long long> = true;
-	template <>	constexpr bool is_primitive_type_v<unsigned long long> = true;
-	template <>	constexpr bool is_primitive_type_v<float> = true;
-	template <>	constexpr bool is_primitive_type_v<double> = true;
+	template <class T> static constexpr bool is_primitive_type_v = false;
+	template <>	static constexpr bool is_primitive_type_v<bool> = true;
+	template <>	static constexpr bool is_primitive_type_v<short> = true;
+	template <>	static constexpr bool is_primitive_type_v<unsigned short> = true;
+	template <>	static constexpr bool is_primitive_type_v<int> = true;
+	template <>	static constexpr bool is_primitive_type_v<unsigned int> = true;
+	template <>	static constexpr bool is_primitive_type_v<long> = true;
+	template <>	static constexpr bool is_primitive_type_v<unsigned long> = true;
+	template <>	static constexpr bool is_primitive_type_v<long long> = true;
+	template <>	static constexpr bool is_primitive_type_v<unsigned long long> = true;
+	template <>	static constexpr bool is_primitive_type_v<float> = true;
+	template <>	static constexpr bool is_primitive_type_v<double> = true;
 
 	// cpp20
 	template <class T>

--- a/lib/source/GLSL450Instruction.cpp
+++ b/lib/source/GLSL450Instruction.cpp
@@ -126,12 +126,12 @@ spvgentwo::Instruction* spvgentwo::GLSL450Intruction::opCross(Instruction* _pLef
 	if (pLeftTypeInstr == nullptr || pRightTypeInstr == nullptr) return this;
 
 	const Type* pType = pLeftTypeInstr->getType();
-	if (pLeftTypeInstr == pRightTypeInstr && pType->isVectorOfScalar(3u))
+	if (pLeftTypeInstr == pRightTypeInstr && pType->isVectorOfFloat(3u))
 	{
 		return opExtInst(pLeftTypeInstr, ExtName, extinstr::GLSLstd450::GLSLstd450Cross, _pLeft, _pRight);	
 	}
 	
-	getModule()->logError("Operands of opCross are not scalar vector of length 3");
+	getModule()->logError("Operands of opCross are not vector of length 3");
 
 	return this;
 }

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -865,6 +865,23 @@ spvgentwo::Instruction* spvgentwo::Instruction::opQuantizeToF16(Instruction* _pF
 	return this;
 }
 
+spvgentwo::Instruction* spvgentwo::Instruction::opConvertPtrToU(Instruction* _pPhysPtr, unsigned int _bitWidth)
+{
+	const Type* type = _pPhysPtr->getType();
+
+	if (type == nullptr) return this;
+
+	if (type->isPointer() && (type->getStorageClass() == spv::StorageClass::PhysicalStorageBuffer || type->getStorageClass() == spv::StorageClass::PhysicalStorageBufferEXT))
+	{
+		Type t(getModule()->newType());
+		return makeOp(spv::Op::OpConvertPtrToU, getModule()->addType(t.UInt(_bitWidth)), InvalidId, _pPhysPtr);
+	}
+
+	getModule()->logError("Operand of OpConvertPtrToU is not a physical pointer type");
+
+	return this;
+}
+
 spvgentwo::Instruction* spvgentwo::Instruction::scalarVecOp(spv::Op _op, spv::Op _type, Sign _sign, Instruction* _pLeft, Instruction* _pRight, const char* _pErrorMsg, bool _checkSign)
 {
 	const Type* pLeftType = _pLeft->getType();

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -793,8 +793,59 @@ spvgentwo::Instruction* spvgentwo::Instruction::opSampledImage(Instruction* _pIm
 		return makeOp(spv::Op::OpSampledImage, InvalidInstr, InvalidId, _pImage, _pSampler);
 	}
 
-	getModule()->logError("Image or sampler type does not match (storage / subpass image not allowed");
+	getModule()->logError("Image or sampler type does not match (storage / subpass image not allowed)");
 	
+	return this;
+}
+
+spvgentwo::Instruction* spvgentwo::Instruction::opUConvert(Instruction* _pUintVec, unsigned int _bitWidth)
+{
+	const Type* type = _pUintVec->getType();
+
+	if (type == nullptr) return this;
+
+	if (Type t = type->getBaseType(); t.isUInt() && t.getIntWidth() != _bitWidth)
+	{
+		t.getBaseType().setIntWidth(_bitWidth);
+		return makeOp(spv::Op::OpUConvert, getModule()->addType(t), InvalidId, _pUintVec);
+	}
+
+	getModule()->logError("Operand of OpUConvert is not a unsigned integer type with differing component width");
+
+	return this;
+}
+
+spvgentwo::Instruction* spvgentwo::Instruction::opSConvert(Instruction* _pSIntVec, unsigned int _bitWidth)
+{
+	const Type* type = _pSIntVec->getType();
+
+	if (type == nullptr) return this;
+
+	if (Type t = type->getBaseType(); t.isSInt() && t.getIntWidth() != _bitWidth)
+	{
+		t.getBaseType().setIntWidth(_bitWidth);
+		return makeOp(spv::Op::OpSConvert, getModule()->addType(t), InvalidId, _pSIntVec);
+	}
+
+	getModule()->logError("Operand of OpsConvert is not a signed integer type with differing component width");
+
+	return this;
+}
+
+spvgentwo::Instruction* spvgentwo::Instruction::opFConvert(Instruction* _pFloatVec, unsigned int _bitWidth)
+{
+	const Type* type = _pFloatVec->getType();
+
+	if (type == nullptr) return this;
+
+	if (Type t = type->getBaseType(); t.isFloat() && t.getFloatWidth() != _bitWidth)
+	{
+		t.getBaseType().setFloatWidth(_bitWidth);
+		return makeOp(spv::Op::OpFConvert, getModule()->addType(t), InvalidId, _pFloatVec);
+	}
+
+	getModule()->logError("Operand of OpFConvert is not a unsigned integer type with differing component width");
+
 	return this;
 }
 

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -882,6 +882,31 @@ spvgentwo::Instruction* spvgentwo::Instruction::opConvertPtrToU(Instruction* _pP
 	return this;
 }
 
+spvgentwo::Instruction* spvgentwo::Instruction::opBitcast(Instruction* _pResultType, Instruction* _pOperand)
+{
+	const Type* resultType = _pResultType->getType();
+	const Type* operandType = _pOperand->getType();
+
+	if (resultType == nullptr || operandType == nullptr) return this;
+
+	if (*resultType == *operandType)
+	{
+		getModule()->logError("Operand and result type of OpBitcast are identical");
+		return this;
+	}
+
+	if ((operandType->isPointer() && resultType->isPointer()) || 
+		(operandType->getScalarOrVectorLength() * operandType->getBaseType().getIntWidth() ==
+			resultType->getScalarOrVectorLength() * resultType->getBaseType().getIntWidth()))
+	{
+		return makeOp(spv::Op::OpBitcast, _pResultType, InvalidId, _pOperand);
+	}
+
+	getModule()->logError("Operand or result type of OpBitcast is not a pointer or numerical scalar or vector type whose total bitwidth match");
+
+	return this;
+}
+
 spvgentwo::Instruction* spvgentwo::Instruction::scalarVecOp(spv::Op _op, spv::Op _type, Sign _sign, Instruction* _pLeft, Instruction* _pRight, const char* _pErrorMsg, bool _checkSign)
 {
 	const Type* pLeftType = _pLeft->getType();

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -668,10 +668,10 @@ spvgentwo::Instruction* spvgentwo::Instruction::opSelect(Instruction* _pCondBool
 	const Type* falseType = _pFalseObj->getType();
 	const Type* condType = _pCondBool->getType();
 
-	if (trueType == nullptr || falseType == false || condType == false) return this;
+	if (trueType == nullptr || falseType == nullptr || condType == nullptr) return this;
 
 	if (*trueType == *falseType && condType->isScalarOrVectorOf(spv::Op::OpTypeBool) && 
-		condType->getVectorComponentCount() == trueType->getVectorComponentCount())
+		condType->getScalarOrVectorLength() == trueType->getScalarOrVectorLength())
 	{
 		// Before version1.4, results are only computed per component.
 		// Before version1.4, Result Type must be a pointer, scalar, or vector.Starting withv ersion1.4, Result Type can additionally be a composite type other than a vector.

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -871,7 +871,7 @@ spvgentwo::Instruction* spvgentwo::Instruction::opConvertPtrToU(Instruction* _pP
 
 	if (type == nullptr) return this;
 
-	if (type->isPointer() && (type->getStorageClass() == spv::StorageClass::PhysicalStorageBuffer || type->getStorageClass() == spv::StorageClass::PhysicalStorageBufferEXT))
+	if (type->isPointer() && type->getStorageClass() == spv::StorageClass::PhysicalStorageBuffer)
 	{
 		Type t(getModule()->newType());
 		return makeOp(spv::Op::OpConvertPtrToU, getModule()->addType(t.UInt(_bitWidth)), InvalidId, _pPhysPtr);


### PR DESCRIPTION
This PR adds:

		Instruction* opUConvert(Instruction* _pUIntVec, unsigned int _bitWidth);

		Instruction* opSConvert(Instruction* _pSIntVec, unsigned int _bitWidth);

		Instruction* opFConvert(Instruction* _pFloatVec, unsigned int _bitWidth);

		Instruction* opQuantizeToF16(Instruction* _pFloatVec);

		Instruction* opConvertPtrToU(Instruction* _pPhysPtr, unsigned int _bitWidth);

		Instruction* opBitcast(Instruction* _pResultType, Instruction* _pOperand);

		template<class T> // generic version of opBitcast, generates spv type from T
		Instruction* bitcast(Instruction* _pOperand);

and improves & fixes some Type helpers.
Fix new clang linker problem.