### PR TITLE
Downgrade CMake require verison to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10.0 FATAL_ERROR)
 
 macro(add_sources expression sources)
 	file(GLOB source_files RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "${expression}")


### PR DESCRIPTION
I was able to get SHADERed to build on Ubuntu 18.04 LTS, but the CMake that's provided by the ubuntu repos is a little not up to the latest version.  When I changed the required CMake version of this project to 3.10, it built without a single problem.