### PR TITLE
Core instructions #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ SPIR-V IR generation progress, parsing is independent and auto generated. This t
 | OpImageTexelPointer | &#9744; |
 | OpLoad | &#10004; |
 | OpStore | &#10004; |
-| OpCopyMemory | &#9744; |
+| OpCopyMemory | &#10004; |
 | OpCopyMemorySized | &#9744; |
 | OpAccessChain | &#10004; |
 | OpInBoundsAccessChain | &#10004; |

--- a/README.md
+++ b/README.md
@@ -120,14 +120,16 @@ The resulting SPIR-V binary when disassembled using `spirv-dis`:
 
 Set CMake option SPVGENTWO_BUILD_EXAMPLES to TRUE to build included examples:
 
-* [FunctionCall Example](example/source/FunctionCall.cpp)
+* [Types Example](example/source/Types.cpp)
+* [Constants Example](example/source/Constants.cpp)
 * [ControlFlow Example](example/source/ControlFlow.cpp)
 * [FunctionCall Example](example/source/FunctionCall.cpp)
 * [Extensions Example](example/source/Extensions.cpp)
-* [Constants Example](example/source/Constants.cpp)
-* [Types Example](example/source/Types.cpp)
 * [ExpressionGraph Example](example/source/ExpressionGraph.cpp)
 * [Linkage Example](example/source/Linkage.cpp)
+* [FragmentShader Example](example/source/FragmentShader.cpp)
+* [GeometryShader Example](example/source/GeometryShader.cpp)
+* [ComputeShader Example](example/source/ComputeShader.cpp)
 
 # Project Structure
 
@@ -294,7 +296,7 @@ SPIR-V IR generation progress, parsing is independent and auto generated. This t
 | OpAccessChain | &#10004; |
 | OpInBoundsAccessChain | &#10004; |
 | OpPtrAccessChain | &#9744; |
-| OpArrayLength | &#9744; |
+| OpArrayLength | &#10004; |
 | OpGenericPtrMemSemantics | &#9744; |
 | OpInBoundsPtrAccessChain | &#9744; |
 | OpDecorate | &#10004; |

--- a/README.md
+++ b/README.md
@@ -301,9 +301,9 @@ SPIR-V IR generation progress, parsing is independent and auto generated. This t
 | OpInBoundsPtrAccessChain | &#9744; |
 | OpDecorate | &#10004; |
 | OpMemberDecorate | &#10004; |
-| OpDecorationGroup | &#9744; |
-| OpGroupDecorate | &#9744; |
-| OpGroupMemberDecorate | &#9744; |
+| OpDecorationGroup | Deperecated |
+| OpGroupDecorate | Deperecated|
+| OpGroupMemberDecorate |Deperecated|
 | OpVectorExtractDynamic | &#10004; |
 | OpVectorInsertDynamic | &#10004; |
 | OpVectorShuffle | &#10004; |
@@ -379,14 +379,14 @@ SPIR-V IR generation progress, parsing is independent and auto generated. This t
 | OpSMulExtended | &#9744; |
 | OpAny | &#10004; |
 | OpAll | &#10004; |
-| OpIsNan | &#9744; |
-| OpIsInf | &#9744; |
-| OpIsFinite | &#9744; |
-| OpIsNormal | &#9744; |
-| OpSignBitSet | &#9744; |
-| OpLessOrGreater | &#9744; |
-| OpOrdered | &#9744; |
-| OpUnordered | &#9744; |
+| OpIsNan | &#10004; |
+| OpIsInf | &#10004; |
+| OpIsFinite | &#10004; |
+| OpIsNormal | &#10004; |
+| OpSignBitSet | &#10004; |
+| OpLessOrGreater | Deperecated |
+| OpOrdered | &#10004; |
+| OpUnordered | &#10004; |
 | OpLogicalEqual | &#10004; |
 | OpLogicalNotEqual | &#10004; |
 | OpLogicalOr | &#10004; |

--- a/README.md
+++ b/README.md
@@ -343,8 +343,8 @@ SPIR-V IR generation progress, parsing is independent and auto generated. This t
 | OpFConvert | &#10004; |
 | OpQuantizeToF16 | &#10004; |
 | OpConvertPtrToU | &#10004; |
-| OpSatConvertSToU | &#9744; |
-| OpSatConvertUToS | &#9744; |
+| OpSatConvertSToU | &#10004; |
+| OpSatConvertUToS | &#10004; |
 | OpConvertUToPtr | &#9744; |
 | OpPtrCastToGeneric | &#9744; |
 | OpGenericCastToPtr | &#9744; |

--- a/README.md
+++ b/README.md
@@ -373,10 +373,10 @@ SPIR-V IR generation progress, parsing is independent and auto generated. This t
 | OpMatrixTimesMatrix | &#10004; |
 | OpOuterProduct | &#10004; |
 | OpDot | &#10004; |
-| OpIAddCarry | &#9744; |
-| OpISubBorrow | &#9744; |
-| OpUMulExtended | &#9744; |
-| OpSMulExtended | &#9744; |
+| OpIAddCarry | &#10004; |
+| OpISubBorrow | &#10004; |
+| OpUMulExtended | &#10004; |
+| OpSMulExtended | &#10004; |
 | OpAny | &#10004; |
 | OpAll | &#10004; |
 | OpIsNan | &#10004; |

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ SPIR-V IR generation progress, parsing is independent and auto generated. This t
 | OpLoad | &#10004; |
 | OpStore | &#10004; |
 | OpCopyMemory | &#10004; |
-| OpCopyMemorySized | &#9744; |
+| OpCopyMemorySized | &#10004; |
 | OpAccessChain | &#10004; |
 | OpInBoundsAccessChain | &#10004; |
 | OpPtrAccessChain | &#9744; |

--- a/common/include/common/Algorithms.h
+++ b/common/include/common/Algorithms.h
@@ -2,7 +2,7 @@
 
 #include "spvgentwo/stdreplacement.h"
 
-namespace spvgentwo
+namespace spvgentwo::algo
 {
 	// transform a Container<Elem> to a Container<Func(Elem)>
 	template <class Elem, template <typename T> class Container, class Func>
@@ -33,5 +33,33 @@ namespace spvgentwo
 		}
 
 		return output;
+	}
+
+	template <class Elem, template <typename T> class Container, class Func>
+	bool any(const Container<Elem>& _input, const Func& _func)
+	{
+		static_assert(traits::is_invocable_v<Func, const Elem&>, "Func not invocable with const Elem&");
+	
+		for (const Elem& elem : _input)
+		{
+			if (_func(elem))
+				return true;
+		}
+
+		return false;
+	}
+
+	template <class Elem, template <typename T> class Container, class Func>
+	bool all(const Container<Elem>& _input, const Func& _func)
+	{
+		static_assert(traits::is_invocable_v<Func, const Elem&>, "Func not invocable with const Elem&");
+
+		for (const Elem& elem : _input)
+		{
+			if (_func(elem) == false)
+				return false;
+		}
+
+		return true;
 	}
 } //!spvgentwo

--- a/common/include/common/ExprGraph.h
+++ b/common/include/common/ExprGraph.h
@@ -50,8 +50,8 @@ namespace spvgentwo
 		{
 			if constexpr (args == ExprArgs::FunctionPtrLists)
 			{
-				auto inputs = transform(_pExitNode->inputs(), [](auto& edge) -> Func* {return &edge.pTarget->data().get(); });
-				auto outputs = transform(_pExitNode->outputs(), [](auto& edge) -> Func* {return &edge.pTarget->data().get(); });
+				auto inputs = algo::transform(_pExitNode->inputs(), [](auto& edge) -> Func* {return &edge.pTarget->data().get(); });
+				auto outputs = algo::transform(_pExitNode->outputs(), [](auto& edge) -> Func* {return &edge.pTarget->data().get(); });
 				expr(inputs, outputs);
 			}
 			else

--- a/example/include/example/ComputeShader.h
+++ b/example/include/example/ComputeShader.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "spvgentwo/Module.h"
+
+namespace examples
+{
+	spvgentwo::Module computeShader(spvgentwo::IAllocator* _pAllocator, spvgentwo::ILogger* _pLogger);
+} // !examples

--- a/example/source/ComputeShader.cpp
+++ b/example/source/ComputeShader.cpp
@@ -59,6 +59,13 @@ spvgentwo::Module examples::computeShader(spvgentwo::IAllocator* _pAllocator, sp
 		bb->opSatConvertSToU(module.constant(13u));
 		bb->opSatConvertUToS(module.constant(1337u));
 
+		Instruction* intVec1 = module.constant(make_vector(0u, 3u, 4u));
+		Instruction* intVec2 = module.constant(make_vector(3u, 0u, 4u));
+
+		bb->opIAddCarry(intVec1, intVec2);
+		bb->opISubBorrow(intVec2, intVec1);
+		bb->opUMulExtended(intVec1, intVec1);
+
 		bb.returnValue();
 	}
 

--- a/example/source/ComputeShader.cpp
+++ b/example/source/ComputeShader.cpp
@@ -11,6 +11,8 @@ spvgentwo::Module examples::computeShader(spvgentwo::IAllocator* _pAllocator, sp
 	// configure capabilities and extensions
 	module.addCapability(spv::Capability::Shader);
 	module.addCapability(spv::Capability::Kernel);
+	module.addCapability(spv::Capability::Addresses);
+	module.addCapability(spv::Capability::Int64);
 
 	// global variables
 
@@ -51,7 +53,8 @@ spvgentwo::Module examples::computeShader(spvgentwo::IAllocator* _pAllocator, sp
 		bb->opUnordered(f3, g3);
 
 		Instruction* target = entry.variable<complex>("func_Array");
-		bb->opCopyMemory(target, uniArray);		
+		auto* zero = module.constant(1ull);
+		bb->opCopyMemorySized(target, uniArray, zero);		
 
 		bb.returnValue();
 	}

--- a/example/source/ComputeShader.cpp
+++ b/example/source/ComputeShader.cpp
@@ -33,6 +33,19 @@ spvgentwo::Module examples::computeShader(spvgentwo::IAllocator* _pAllocator, sp
 
 		Instruction* arLength = bb->opArrayLength(uniRtArray, 0u);
 
+		Instruction* f3 = entry.variable(make_vector(1.f, -3.f, 1.f / -0.01f));
+		f3 = bb->opLoad(f3);
+
+		Instruction* g3 = bb->Div(f3, module.constant(-0.0f));
+
+		bb->opIsNan(g3);
+		bb->opIsInf(f3);
+		bb->opIsFinite(g3);
+		bb->opIsNormal(f3);
+		bb->opSignBitSet(g3);
+		bb->opOrdered(f3, g3);
+		bb->opUnordered(f3, g3);
+
 		bb.returnValue();
 	}
 

--- a/example/source/ComputeShader.cpp
+++ b/example/source/ComputeShader.cpp
@@ -56,6 +56,9 @@ spvgentwo::Module examples::computeShader(spvgentwo::IAllocator* _pAllocator, sp
 		auto* zero = module.constant(1ull);
 		bb->opCopyMemorySized(target, uniArray, zero);		
 
+		bb->opSatConvertSToU(module.constant(13u));
+		bb->opSatConvertUToS(module.constant(1337u));
+
 		bb.returnValue();
 	}
 

--- a/example/source/ComputeShader.cpp
+++ b/example/source/ComputeShader.cpp
@@ -25,6 +25,10 @@ spvgentwo::Module examples::computeShader(spvgentwo::IAllocator* _pAllocator, sp
 
 	Instruction* uniRtArray = module.uniform(stArray, "u_RtArray");
 
+	using complex = array_t<vector_t<float, 4>, 8>;
+
+	Instruction* uniArray = module.uniform<complex>("u_Array");
+
 	// void main(); entry point
 	{
 		EntryPoint& entry = module.addEntryPoint(spv::ExecutionModel::Kernel, "main");
@@ -45,6 +49,9 @@ spvgentwo::Module examples::computeShader(spvgentwo::IAllocator* _pAllocator, sp
 		bb->opSignBitSet(g3);
 		bb->opOrdered(f3, g3);
 		bb->opUnordered(f3, g3);
+
+		Instruction* target = entry.variable<complex>("func_Array");
+		bb->opCopyMemory(target, uniArray);		
 
 		bb.returnValue();
 	}

--- a/example/source/ComputeShader.cpp
+++ b/example/source/ComputeShader.cpp
@@ -1,0 +1,40 @@
+#include "example/ComputeShader.h"
+#include "spvgentwo/Templates.h"
+
+using namespace spvgentwo;
+
+spvgentwo::Module examples::computeShader(spvgentwo::IAllocator* _pAllocator, spvgentwo::ILogger* _pLogger)
+{
+	// create a new spir-v module
+	Module module(_pAllocator, _pLogger);
+
+	// configure capabilities and extensions
+	module.addCapability(spv::Capability::Shader);
+	module.addCapability(spv::Capability::Kernel);
+
+	// global variables
+
+	//struct
+	//{
+	//	float x[];
+	//};
+
+	Type stArray = module.newType().Struct();
+	// add runt-time float array
+	stArray.Member().RuntimeArrayElement().Float();
+
+	Instruction* uniRtArray = module.uniform(stArray, "u_RtArray");
+
+	// void main(); entry point
+	{
+		EntryPoint& entry = module.addEntryPoint(spv::ExecutionModel::Kernel, "main");
+
+		BasicBlock& bb = *entry; // get entry block to this function
+
+		Instruction* arLength = bb->opArrayLength(uniRtArray, 0u);
+
+		bb.returnValue();
+	}
+
+	return module;
+}

--- a/example/source/OldInstrTest.cpp
+++ b/example/source/OldInstrTest.cpp
@@ -71,6 +71,8 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 
 		Instruction* intvec = module.constant(const_vector_t<int, 3>{1, -3, 2});
 
+		bb->OpSMulExtended(intvec, intvec);
+
 		Instruction* signs = bb.ext<GLSL>()->opSSign(intvec);
 		Instruction* abs = bb.ext<GLSL>()->opSAbs(signs);
 		Instruction* smin = bb.ext<GLSL>()->opSMin(abs, signs);

--- a/example/source/Types.cpp
+++ b/example/source/Types.cpp
@@ -57,6 +57,11 @@ Module examples::types(IAllocator* _pAllocator, ILogger* _pLogger)
 		// add complex dynamic C++ type
 		type = module.type<dyn_sampled_image_t>(img);
 
+		auto ty = [&module](){ return module.newType(); };
+
+		Type t(ty());
+		module.addType(t.Struct(ty().Float(), ty().UInt(), ty().Bool()));
+
 		bb.returnValue();
 	}
 

--- a/example/source/example.cpp
+++ b/example/source/example.cpp
@@ -17,6 +17,7 @@
 #include "example/ExpressionGraph.h"
 #include "example/GeometryShader.h"
 #include "example/FragmentShader.h"
+#include "example/ComputeShader.h"
 #include "example/Linkage.h"
 
 #include <cstdarg>
@@ -76,6 +77,15 @@ int main()
 	TestLogger log;
 	HeapAllocator alloc; // custom user allocator
 	const Grammar gram(&alloc);
+
+	// fragment shader example
+	if (BinaryFileWriter writer(alloc, "compute.spv"); writer.isOpen())
+	{
+		examples::computeShader(&alloc, &log).finalizeAndWrite(writer);
+		writer.close();
+		system("spirv-dis compute.spv");
+		assert(system("spirv-val compute.spv") == 0);
+	}
 
 	{
 		Module libA, libB, consumer;

--- a/lib/include/spvgentwo/Flag.h
+++ b/lib/include/spvgentwo/Flag.h
@@ -58,6 +58,7 @@ namespace spvgentwo
 		constexpr operator bool() const { return mask != 0u; }
 		constexpr operator unsigned int() const { return mask; }
 		constexpr operator Enum() const { return static_cast<Enum>(mask); }
+		constexpr bool empty() const { return mask == 0u; }
 
 		template <class ... TEnum> // check if any of the enum flags is set
 		constexpr bool any(Enum _first, TEnum ... _enums) const { return (mask & detail::bit_or(_first, _enums...)) != 0u; }

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -314,9 +314,9 @@ namespace spvgentwo
 		template <class ... Decorations>
 		void opMemberDecorate(Instruction* _pTargetStructType, unsigned int _memberIndex, spv::Decoration _decoration, Decorations ... _decorations);
 
-		// Instruction* OpDecorationGroup(); TODO
-		// Instruction* OpGroupDecorate(); TODO
-		// Instruction* OpGroupMemberDecorate(); TODO
+		// Instruction* OpDecorationGroup(); Deprecated
+		// Instruction* OpGroupDecorate(); Deprecated
+		// Instruction* OpGroupMemberDecorate(); Deprecated
 
 		Instruction* opVectorExtractDynamic(Instruction* _pVector, Instruction* _pIndexInt);
 
@@ -493,8 +493,10 @@ namespace spvgentwo
 
 		Instruction* opConvertPtrToU(Instruction* _pPhysPtr, unsigned int _bitWidth);
 
-		// Instruction* OpSatConvertSToU(); TODO
-		// Instruction* OpSatConvertUToS(); TODO
+		Instruction* opSatConvertSToU(Instruction* _pSignedInt) { return scalarVecOp(spv::Op::OpSatConvertSToU, _pSignedInt, nullptr, "Operand of OpSatConvertSToU is not a scalar or vector of signed integer type"); }
+		
+		Instruction* opSatConvertUToS(Instruction* _pSignedInt) { return scalarVecOp(spv::Op::OpSatConvertUToS, _pSignedInt, nullptr, "Operand of OpSatConvertUToS is not a scalar or vector of unsigned integer type"); }
+
 		// Instruction* OpConvertUToPtr(); TODO
 		// Instruction* OpPtrCastToGeneric(); TODO
 		// Instruction* OpGenericCastToPtr(); TODO

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -273,8 +273,17 @@ namespace spvgentwo
 		template <class ... Operands>
 		void opStore(Instruction* _pPointerToVar, Instruction* _valueToStore, const Flag<spv::MemoryAccessMask> _memOperands = spv::MemoryAccessMask::MaskNone, Operands ... _operands);
 
-		void opCopyMemory(Instruction* _pTargetPtr, Instruction* _pSourcePtr, Flag<spv::MemoryAccessMask> _targetMemOperands = spv::MemoryAccessMask::MaskNone, Flag<spv::MemoryAccessMask> _sourceMemOperands = spv::MemoryAccessMask::MaskNone);
-		// void OpCopyMemorySized(); TODO
+		template <class ... Operands>
+		void opCopyMemory(Instruction* _pTargetPtr, Instruction* _pSourcePtr, Flag<spv::MemoryAccessMask> _targetMemOperands = spv::MemoryAccessMask::MaskNone, Flag<spv::MemoryAccessMask> _sourceMemOperands = spv::MemoryAccessMask::MaskNone, Operands ... _operands)
+		{
+			opCopyMemorySizedImpl(_pTargetPtr, _pSourcePtr, nullptr, _targetMemOperands, _sourceMemOperands, _operands...);
+		}
+		
+		template <class ... Operands>
+		void opCopyMemorySized(Instruction* _pTargetPtr, Instruction* _pSourcePtr, Instruction* _pSizeInBytesInt, Flag<spv::MemoryAccessMask> _targetMemOperands = spv::MemoryAccessMask::MaskNone, Flag<spv::MemoryAccessMask> _sourceMemOperands = spv::MemoryAccessMask::MaskNone, Operands ... _operands)
+		{
+			opCopyMemorySizedImpl(_pTargetPtr, _pSourcePtr, _pSizeInBytesInt, _targetMemOperands, _sourceMemOperands, _operands...);
+		}
 
 		// ConstInstr must be OpConstant (unsigne int) Instruction
 		template <class ... ConstInstr>
@@ -683,6 +692,7 @@ namespace spvgentwo
 		template <class ... VarInst>
 		Instruction* opPhi(Instruction* _pVar, VarInst* ... _variables);
 
+		// Non-Standard helper
 		Instruction* opPhiDynamic(const List<Instruction*>& _variables);
 
 		template <class ...LoopControlParams>
@@ -734,6 +744,9 @@ namespace spvgentwo
 	protected:
 		// return error instr
 		[[nodiscard]] Instruction* error() const;
+
+		template <class ... Operands>
+		void opCopyMemorySizedImpl(Instruction* _pTargetPtr, Instruction* _pSourcePtr, Instruction* _pSizeInt, Flag<spv::MemoryAccessMask> _targetMemOperands = spv::MemoryAccessMask::MaskNone, Flag<spv::MemoryAccessMask> _sourceMemOperands = spv::MemoryAccessMask::MaskNone, Operands ... _operands);
 
 		enum class CheckImgCoord
 		{

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -551,15 +551,21 @@ namespace spvgentwo
 
 		Instruction* opAll(Instruction* _pBoolVec);
 
-		// Instruction* OpIsNan(); TODO
-		// Instruction* OpIsInf(); TODO
-		// Instruction* OpIsFinite(); TODO
-		// Instruction* OpIsNormal(); TODO
-		// Instruction* OpSignBitSet(); TODO
+		Instruction* opIsNan(Instruction* _pFloatVec) { return scalarVecOp(spv::Op::OpIsNan, _pFloatVec, nullptr, "Operand of OpIsNan is not a scalar or vector of float type", false); }
 
-		// Instruction* OpLessOrGreater(); TODO
-		// Instruction* OpOrdered(); TODO
-		// Instruction* OpUnordered(); TODO
+		Instruction* opIsInf(Instruction* _pFloatVec) { return scalarVecOp(spv::Op::OpIsInf, _pFloatVec, nullptr, "Operand of OpIsInf is not a scalar or vector of float type", false); }
+
+		Instruction* opIsFinite(Instruction* _pFloatVec) { return scalarVecOp(spv::Op::OpIsFinite, _pFloatVec, nullptr, "Operand of OpIsFinite is not a scalar or vector of float type", false); }
+
+		Instruction* opIsNormal(Instruction* _pFloatVec) { return scalarVecOp(spv::Op::OpIsNormal, _pFloatVec, nullptr, "Operand of OpIsNormal is not a scalar or vector of float type", false); }
+
+		Instruction* opSignBitSet(Instruction* _pFloatVec) { return scalarVecOp(spv::Op::OpSignBitSet, _pFloatVec, nullptr, "Operand of OpSignBitSet is not a scalar or vector of float type", false); }
+
+		// Instruction* OpLessOrGreater(); DEPRECATED
+		
+		Instruction* opOrdered(Instruction* _pFloatVec1, Instruction* _pFloatVec2) { return scalarVecOp(spv::Op::OpOrdered, _pFloatVec1, _pFloatVec2, "Operand of OpOrdered is not a scalar or vector of bool type"); }
+
+		Instruction* opUnordered(Instruction* _pFloatVec1, Instruction* _pFloatVec2) { return scalarVecOp(spv::Op::OpUnordered, _pFloatVec1, _pFloatVec2, "Operand of OpUnordered is not a scalar or vector of bool type"); }
 
 		Instruction* opLogicalEqual(Instruction* _pBoolVec1, Instruction* _pBoolVec2) { return scalarVecOp(spv::Op::OpLogicalEqual, _pBoolVec1, _pBoolVec2, "Operand of OpLogicalEqual is not a scalar or vector of bool type"); }
 

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -273,8 +273,8 @@ namespace spvgentwo
 		template <class ... Operands>
 		void opStore(Instruction* _pPointerToVar, Instruction* _valueToStore, const Flag<spv::MemoryAccessMask> _memOperands = spv::MemoryAccessMask::MaskNone, Operands ... _operands);
 
-		// Instruction* OpCopyMemory(); TODO
-		// Instruction* OpCopyMemorySized(); TODO
+		void opCopyMemory(Instruction* _pTargetPtr, Instruction* _pSourcePtr, Flag<spv::MemoryAccessMask> _targetMemOperands = spv::MemoryAccessMask::MaskNone, Flag<spv::MemoryAccessMask> _sourceMemOperands = spv::MemoryAccessMask::MaskNone);
+		// void OpCopyMemorySized(); TODO
 
 		// ConstInstr must be OpConstant (unsigne int) Instruction
 		template <class ... ConstInstr>

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -553,10 +553,13 @@ namespace spvgentwo
 
 		Instruction* opDot(Instruction* _pLeft, Instruction* _pRight);
 
-		// Instruction* OpIAddCarry(); TODO
-		// Instruction* OpISubBorrow(); TODO
-		// Instruction* OpUMulExtended(); TODO
-		// Instruction* OpSMulExtended(); TODO
+		Instruction* opIAddCarry(Instruction* _pUIntVec1, Instruction* _pUIntVec2) { return scalarVecOp(spv::Op::OpIAddCarry, _pUIntVec1, _pUIntVec2, "Operand of OpIAddCarry is not a scalar or vector of unsigned int type"); }
+		
+		Instruction* opISubBorrow(Instruction* _pUIntVec1, Instruction* _pUIntVec2) { return scalarVecOp(spv::Op::OpISubBorrow, _pUIntVec1, _pUIntVec2, "Operand of OpISubBorrow is not a scalar or vector of unsigned int type"); }
+
+		Instruction* opUMulExtended(Instruction* _pUIntVec1, Instruction* _pUIntVec2) { return scalarVecOp(spv::Op::OpUMulExtended, _pUIntVec1, _pUIntVec2, "Operand of OpUMulExtended is not a scalar or vector of unsigned int type"); }
+
+		Instruction* OpSMulExtended(Instruction* _pSIntVec1, Instruction* _pSIntVec2) { return scalarVecOp(spv::Op::OpSMulExtended, _pSIntVec1, _pSIntVec2, "Operand of OpSMulExtended is not a scalar or vector of signed int type"); }
 
 		Instruction* opAny(Instruction* _pBoolVec);
 

--- a/lib/include/spvgentwo/Instruction.h
+++ b/lib/include/spvgentwo/Instruction.h
@@ -292,7 +292,10 @@ namespace spvgentwo
 		Instruction* opInBoundsAccessChain(Instruction* _pResultType, Instruction* _pBase, Instruction* _pConstElementIndex, ConstInstr* ... _pIndices);
 
 		// Instruction* OpPtrAccessChain(); TODO
-		// Instruction* OpArrayLength(); TODO
+
+		//Structure must be a logical pointer to an OpTypeStruct whose last	member is a run-time array.
+		Instruction* opArrayLength(Instruction* _pStructure, unsigned int _ArrayMemberIndex);
+
 		// Instruction* OpGenericPtrMemSemantics(); TODO
 		// Instruction* OpInBoundsPtrAccessChain(); TODO
 

--- a/lib/include/spvgentwo/SpvDefines.h
+++ b/lib/include/spvgentwo/SpvDefines.h
@@ -163,6 +163,7 @@ namespace spvgentwo
 		case spv::Op::OpSNegate:
 		case spv::Op::OpSRem:
 		case spv::Op::OpConvertSToF:
+
 			_sign = Sign::Signed;
 			return spv::Op::OpTypeInt;
 
@@ -186,6 +187,9 @@ namespace spvgentwo
 		case spv::Op::OpBitwiseOr:
 		case spv::Op::OpBitwiseXor:
 		case spv::Op::OpBitwiseAnd:
+		case spv::Op::OpSatConvertUToS:
+		case spv::Op::OpSatConvertSToU:
+
 			_sign = Sign::Any;
 			return spv::Op::OpTypeInt;
 
@@ -205,6 +209,8 @@ namespace spvgentwo
 		case spv::Op::OpUMulExtended:
 		case spv::Op::OpUSubSatINTEL:
 		case spv::Op::OpConvertUToF:
+		case spv::Op::OpConvertUToPtr:
+
 			_sign = Sign::Unsigned;
 			return spv::Op::OpTypeInt;
 

--- a/lib/include/spvgentwo/SpvDefines.h
+++ b/lib/include/spvgentwo/SpvDefines.h
@@ -169,7 +169,6 @@ namespace spvgentwo
 
 		case spv::Op::OpTypeInt:
 		case spv::Op::OpIAdd:
-		case spv::Op::OpIAddCarry:
 		case spv::Op::OpIAddSatINTEL:
 		case spv::Op::OpIAverageINTEL:
 		case spv::Op::OpIAverageRoundedINTEL:
@@ -178,7 +177,6 @@ namespace spvgentwo
 		case spv::Op::OpIMul:
 		case spv::Op::OpIMul32x16INTEL:
 		case spv::Op::OpISub:
-		case spv::Op::OpISubBorrow:
 		case spv::Op::OpISubSatINTEL:
 		case spv::Op::OpNot:
 		case spv::Op::OpShiftRightLogical:
@@ -210,6 +208,11 @@ namespace spvgentwo
 		case spv::Op::OpUSubSatINTEL:
 		case spv::Op::OpConvertUToF:
 		case spv::Op::OpConvertUToPtr:
+
+			// The member type must be a scalar or vector of integer type, whose Signedness operand is 0
+			// Operand 1 and Operand 2 must have the same type as the members of Result Type. => unsigned int
+		case spv::Op::OpIAddCarry:
+		case spv::Op::OpISubBorrow:
 
 			_sign = Sign::Unsigned;
 			return spv::Op::OpTypeInt;

--- a/lib/include/spvgentwo/Type.h
+++ b/lib/include/spvgentwo/Type.h
@@ -111,6 +111,10 @@ namespace spvgentwo
 		constexpr bool isBaseTypeOf(const spv::Op _type) const { return getBaseType().getType() == _type; }
 		constexpr bool hasSameBase(const Type& _other, const bool _onlyCheckTypeOp = false) const;
 
+		// checks if this, or any subtype equals _sub/_type
+		bool containsType(const Type& _sub) const;
+		bool containsType(const spv::Op _type) const;
+
 		// dimension, bits, elements
 		constexpr unsigned int getIntWidth() const { return m_IntWidth; }
 		void setIntWidth(const unsigned int _width) { m_IntWidth = _width; }

--- a/lib/include/spvgentwo/Type.h
+++ b/lib/include/spvgentwo/Type.h
@@ -167,6 +167,9 @@ namespace spvgentwo
 		// return new subtype, if _pSubType is not nullptr, returned member type is a copy of _pSubType
 		Type& Member(const Type* _pSubType = nullptr);
 
+		// return new subtype, if _pSubType is not nullptr, returns this structure
+		Type& MemberM(const Type* _pSubType = nullptr) { Member(_pSubType); return *this; }
+
 		// makes this a void type
 		Type& Void();
 

--- a/lib/include/spvgentwo/Type.h
+++ b/lib/include/spvgentwo/Type.h
@@ -197,6 +197,10 @@ namespace spvgentwo
 		// makes this a struct
 		Type& Struct(const Type* _pSubType = nullptr);
 
+		// make this a struct with _firstMember and _memberTypes as subtypes, returns this sturcture
+		template <class ...Types>
+		Type& Struct(const Type& _firstMember, const Types& ... _memberTypes);
+
 		// makes this an array
 		Type& Array(const unsigned int _elements = 0u, const Type* _elementType = nullptr);
 		// add new member of type run-time array, returns this structure
@@ -718,6 +722,18 @@ namespace spvgentwo
 		{
 			setProperties(_props...);
 		}
+	}
+
+	template<class ...Types>
+	inline Type& Type::Struct(const Type& _firstMember, const Types& ..._memberTypes)
+	{
+		reset();
+		m_Type = spv::Op::OpTypeStruct;
+
+		m_subTypes.emplace_back(_firstMember);
+		(m_subTypes.emplace_back(_memberTypes), ...);
+
+		return *this;
 	}
 
 	template<class T, class ...Props>

--- a/lib/include/spvgentwo/Type.h
+++ b/lib/include/spvgentwo/Type.h
@@ -192,10 +192,17 @@ namespace spvgentwo
 
 		// makes this an array
 		Type& Array(const unsigned int _elements = 0u, const Type* _elementType = nullptr);
+		// add new member of type run-time array, returns this structure
+		Type& ArrayM(const unsigned int _elements = 0u, const Type* _elementType = nullptr) { Member().Array(_elements, _elementType); return *this; }
 		// makes this an array, returns element type
 		Type& ArrayElement(const unsigned int _elements) { Array(_elements); return Member(); }
 
+		// makes this an run-time
 		Type& RuntimeArray(const Type* _elementType = nullptr);
+		// add new member of type run-time array, returns this structure
+		Type& RuntimeArrayM(const Type* _elementType = nullptr) { Member().RuntimeArray(_elementType); return *this; }
+		// makes this an run-time array, returns element type
+		Type& RuntimeArrayElement() { RuntimeArray(); return Member(); }
 
 		// makes this a function
 		Type& Function();

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -978,49 +978,6 @@ spvgentwo::Instruction* spvgentwo::Instruction::opVariable(Instruction* _pResult
 	}
 }
 
-void spvgentwo::Instruction::opCopyMemory(Instruction* _pTargetPtr, Instruction* _pSourcePtr, Flag<spv::MemoryAccessMask> _targetMemOperands, Flag<spv::MemoryAccessMask> _sourceMemOperands)
-{
-	Module* module = getModule();
-
-	const Type* targetType = _pTargetPtr->getType();
-	const Type* sourceType = _pSourcePtr->getType();
-
-	if (targetType == nullptr || sourceType == nullptr)
-	{
-		return;
-	}
-
-	if(targetType->isPointer() == false || sourceType->isPointer() == false)
-	{
-		module->logError("Operand of OpCopyMemory is not a pointer type");
-		return;
-	}
-	else if(targetType->containsType(spv::Op::OpTypeRuntimeArray) || sourceType->containsType(spv::Op::OpTypeRuntimeArray))
-	{
-		module->logError("Operand of OpCopyMemory must not contain any OpTypeRuntimeArray");
-		return;
-	}
-	else if (targetType->front() != sourceType->front())
-	{
-		module->logError("Operand types for _pTargetPtr and _pSourcePtr of OpCopyMemory don't match");
-		return;
-	}
-
-	if(module->getSpvVersion() <= makeVersion(1u, 4u))
-	{
-		if (_sourceMemOperands != spv::MemoryAccessMask::MaskNone)
-		{
-			module->logWarning("Operand _sourceMemOperands of OpCopyMemory will be ignored for SPIR-V 1.4 and below");
-		}
-
-		makeOp(spv::Op::OpCopyMemory, _pTargetPtr, _pSourcePtr, literal_t{_targetMemOperands});
-	}
-	else
-	{
-		makeOp(spv::Op::OpCopyMemory, _pTargetPtr, _pSourcePtr, literal_t{_targetMemOperands}, literal_t{_sourceMemOperands});	
-	}
-}
-
 spvgentwo::Instruction* spvgentwo::Instruction::opAccessChain(Instruction* _pBase, const List<unsigned int>& _indices)
 {
 	// Base must be a pointer, pointing to the base of a composite object.

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -970,11 +970,54 @@ spvgentwo::Instruction* spvgentwo::Instruction::opVariable(Instruction* _pResult
 {
 	if (_pInitializer == nullptr)
 	{
-		return makeOp(spv::Op::OpVariable, _pResultType, InvalidId, _storageClass);
+		return makeOp(spv::Op::OpVariable, _pResultType, InvalidId, literal_t{ _storageClass });
 	}
 	else
 	{
-		return makeOp(spv::Op::OpVariable, _pResultType, InvalidId, _storageClass, _pInitializer);
+		return makeOp(spv::Op::OpVariable, _pResultType, InvalidId, literal_t{ _storageClass }, _pInitializer);
+	}
+}
+
+void spvgentwo::Instruction::opCopyMemory(Instruction* _pTargetPtr, Instruction* _pSourcePtr, Flag<spv::MemoryAccessMask> _targetMemOperands, Flag<spv::MemoryAccessMask> _sourceMemOperands)
+{
+	Module* module = getModule();
+
+	const Type* targetType = _pTargetPtr->getType();
+	const Type* sourceType = _pSourcePtr->getType();
+
+	if (targetType == nullptr || sourceType == nullptr)
+	{
+		return;
+	}
+
+	if(targetType->isPointer() == false || sourceType->isPointer() == false)
+	{
+		module->logError("Operand of OpCopyMemory is not a pointer type");
+		return;
+	}
+	else if(targetType->containsType(spv::Op::OpTypeRuntimeArray) || sourceType->containsType(spv::Op::OpTypeRuntimeArray))
+	{
+		module->logError("Operand of OpCopyMemory must not contain any OpTypeRuntimeArray");
+		return;
+	}
+	else if (targetType->front() != sourceType->front())
+	{
+		module->logError("Operand types for _pTargetPtr and _pSourcePtr of OpCopyMemory don't match");
+		return;
+	}
+
+	if(module->getSpvVersion() <= makeVersion(1u, 4u))
+	{
+		if (_sourceMemOperands != spv::MemoryAccessMask::MaskNone)
+		{
+			module->logWarning("Operand _sourceMemOperands of OpCopyMemory will be ignored for SPIR-V 1.4 and below");
+		}
+
+		makeOp(spv::Op::OpCopyMemory, _pTargetPtr, _pSourcePtr, literal_t{_targetMemOperands});
+	}
+	else
+	{
+		makeOp(spv::Op::OpCopyMemory, _pTargetPtr, _pSourcePtr, literal_t{_targetMemOperands}, literal_t{_sourceMemOperands});	
 	}
 }
 

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -1022,6 +1022,21 @@ spvgentwo::Instruction* spvgentwo::Instruction::opAccessChain(Instruction* _pBas
 	return error();
 }
 
+spvgentwo::Instruction* spvgentwo::Instruction::opArrayLength(Instruction* _pStructure, unsigned int _ArrayMemberIndex)
+{
+	const Type* type = _pStructure->getType();
+	if (type == nullptr) return error();
+
+
+	if (type->isPointer() == false || type->front().isStruct() == false || type->front().back().isRuntimeArray() == false)
+	{
+		getModule()->logError("Operand _pStructure of OpArrayLength must be a logical pointer to an OpTypeStruct whose last	member is a run-time array");
+		return error();
+	} 
+
+	return makeOp(spv::Op::OpArrayLength, InvalidInstr, InvalidId, _pStructure, literal_t{ _ArrayMemberIndex });
+}
+
 spvgentwo::Instruction* spvgentwo::Instruction::opOuterProduct(Instruction* _pLeft, Instruction* _pRight)
 {
 	const Type* pLeftType = _pLeft->getType();

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -625,7 +625,6 @@ spvgentwo::Instruction* spvgentwo::Instruction::Div(Instruction* _pLeft, Instruc
 	{
 		Instruction* one = nullptr;
 
-		// TODO: find a better way to construct constants from a Type with a value thats not exaclty of type, e.g. getModule()->constant(lType, 1)
 		if (rType->isF32())
 		{
 			one = getModule()->constant(1.f);
@@ -634,19 +633,13 @@ spvgentwo::Instruction* spvgentwo::Instruction::Div(Instruction* _pLeft, Instruc
 		{
 			one = getModule()->constant(1.0);
 		}
-		else if (rType->isInt(32u))
-		{
-			one = getModule()->constant(1u);
-		}
-		else if (rType->isInt(64u))
-		{
-			one = getModule()->constant(1ull);
-		}
+		// there is no OpVectorTimes Scalar (Mul) for integer types
 
 		if (one != nullptr)
 		{			
 			// vec / scalar => vec * ( 1 / scalar )
-			return (*bb)->Mul(_pLeft, Div(one, _pRight));
+			Instruction* factor = Div(one, _pRight); // this instruction
+			return (*bb)->Mul(_pLeft, factor); // new instruction (BasicBlock->operator)
 		}
 	}
 

--- a/lib/source/Type.cpp
+++ b/lib/source/Type.cpp
@@ -766,3 +766,31 @@ spvgentwo::Type spvgentwo::Type::wrapStruct() const
 	st.Struct(this);
 	return st;
 }
+
+bool spvgentwo::Type::containsType(const Type& _sub) const
+{
+	if (*this == _sub)
+		return true;
+
+	for (const Type& sub : m_subTypes)
+	{
+		if (sub.containsType(_sub))
+			return true;
+	}
+
+	return false;
+}
+
+bool spvgentwo::Type::containsType(const spv::Op _type) const
+{
+	if (m_Type == _type)
+		return true;
+
+	for (const Type& sub : m_subTypes)
+	{
+		if (sub.containsType(_type))
+			return true;
+	}
+
+	return false;
+}

--- a/lib/source/TypeInferenceAndValiation.cpp
+++ b/lib/source/TypeInferenceAndValiation.cpp
@@ -264,6 +264,7 @@ spvgentwo::Instruction* spvgentwo::defaultimpl::inferResultType(const spvgentwo:
 	case spv::Op::OpImageQueryOrder:
 	case spv::Op::OpImageQueryLevels:
 	case spv::Op::OpImageQuerySamples:
+	case spv::Op::OpArrayLength:
 		return module->type<unsigned int>();
 
 	case spv::Op::OpImageQuerySizeLod:

--- a/lib/source/TypeInferenceAndValiation.cpp
+++ b/lib/source/TypeInferenceAndValiation.cpp
@@ -62,6 +62,10 @@ spvgentwo::Instruction* spvgentwo::defaultimpl::inferResultType(const spvgentwo:
 	case spv::Op::OpDPdyFine:
 	case spv::Op::OpDPdxCoarse:
 	case spv::Op::OpDPdyCoarse:
+
+	case spv::Op::OpSatConvertSToU: // spec doesnt specify signedness of result type but Kernel-Cap dictates unsigned int.
+	case spv::Op::OpSatConvertUToS: // i assume the parameter type is a valid integer type in Kernel-Cap, so just use that
+
 		return typeInstr1;
 	case spv::Op::OpIAddCarry:
 	case spv::Op::OpISubBorrow:

--- a/lib/source/TypeInferenceAndValiation.cpp
+++ b/lib/source/TypeInferenceAndValiation.cpp
@@ -67,9 +67,17 @@ spvgentwo::Instruction* spvgentwo::defaultimpl::inferResultType(const spvgentwo:
 	case spv::Op::OpSatConvertUToS: // i assume the parameter type is a valid integer type in Kernel-Cap, so just use that
 
 		return typeInstr1;
+
 	case spv::Op::OpIAddCarry:
 	case spv::Op::OpISubBorrow:
-		return module->compositeType(spv::Op::OpTypeStruct, typeInstr1, typeInstr2);
+	case spv::Op::OpUMulExtended:
+	case spv::Op::OpSMulExtended:
+		if (type1 == nullptr || type2 == nullptr) return module->getErrorInstr();
+
+		// Result Type must be from OpTypeStruct. The struct must have two members, and the two members must be the same type.
+		// The member type must be a scalar or vector of integer type, whose Signedness operand is 0. (we assume sign is correct,  excpects signed)
+
+		return module->addType(type1->wrapStruct().MemberM(type2));
 	case spv::Op::OpVectorTimesScalar:
 		return checkType(spv::Op::OpTypeVector, typeInstr1);
 	case spv::Op::OpMatrixTimesScalar:


### PR DESCRIPTION
Add support for:

- OpArrayLength
- OpIsNan
- OpIsInf
- OpIsFinite
- OpIsNormal
- OpSignBitSet
- OpOrdered
- OpUnordered
- OpSatConvertSToU
- OpSatConvertUToS
- OpIAddCarry
- OpISubBorrow
- OpUMulExtended,
- OpSMulExtended