### PR TITLE
wip scalar opSelect

### DIFF
--- a/example/source/OldInstrTest.cpp
+++ b/example/source/OldInstrTest.cpp
@@ -218,9 +218,9 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 		Instruction* vecType = module.type<vector_t<float, 3>>();
 		Instruction* newVec3 = bb->opCompositeConstruct(vecType, x, y, z);
 		Instruction* updatedVec3 = bb->opVectorInsertDynamic(newVec3, extracted, index);
-		Instruction* shuffledVec4 = bb->opVectorShuffle(newVec3, updatedVec3, 0u, 1u, 1u, 2u);
+		Instruction* shuffledVec4a = bb->opVectorShuffle(newVec3, updatedVec3, 0u, 1u, 1u, 2u);
 		Instruction* undefVec3 = bb->opUndef(vecType);
-		shuffledVec4 = bb->opVectorShuffle(undefVec3, updatedVec3, 1u, 2u, 3u, 0u);
+		Instruction* shuffledVec4b = bb->opVectorShuffle(undefVec3, updatedVec3, 1u, 2u, 3u, 0u);
 
 		Instruction* coord = module.constant(make_vector(0.5f, 0.5f));
 		Instruction* normal = bb->opLoad(uniNormal);
@@ -237,6 +237,9 @@ Module examples::oldInstrTest(IAllocator* _pAllocator, ILogger* _pLogger)
 		Instruction* uniX = bb->opLoad(uniformComp);
 
 		Instruction* cond = bb.Equal(uniX, uniY);
+
+		bb->opSelect(cond, shuffledVec4a, shuffledVec4b);
+		bb->opSelect(module.constant(make_vector(true, false, false, true)), shuffledVec4a, shuffledVec4b);
 
 		Instruction* res1 = nullptr;
 		Instruction* res2 = nullptr;

--- a/lib/include/spvgentwo/Module.h
+++ b/lib/include/spvgentwo/Module.h
@@ -32,7 +32,7 @@ namespace spvgentwo
 
 		unsigned int getSpvVersion() const { return m_spvVersion; }
 		void setSpvVersion(unsigned int _version) { m_spvVersion = _version; }
-		void setSpvVersion(unsigned char _major, unsigned char _minor) { m_spvBound = makeVersion(_major, _minor); }
+		void setSpvVersion(unsigned char _major, unsigned char _minor) { m_spvVersion = makeVersion(_major, _minor); }
 
 		unsigned int getMajorVersion() const { return spvgentwo::getMajorVersion(m_spvVersion); }
 		unsigned int getMinorVersion() const { return spvgentwo::getMinorVersion(m_spvVersion); }

--- a/lib/include/spvgentwo/Module.h
+++ b/lib/include/spvgentwo/Module.h
@@ -33,6 +33,7 @@ namespace spvgentwo
 		unsigned int getSpvVersion() const { return m_spvVersion; }
 		void setSpvVersion(unsigned int _version) { m_spvVersion = _version; }
 		void setSpvVersion(unsigned char _major, unsigned char _minor) { m_spvVersion = makeVersion(_major, _minor); }
+		void ensureSpvVersion(unsigned char _major, unsigned char _minor);
 
 		unsigned int getMajorVersion() const { return spvgentwo::getMajorVersion(m_spvVersion); }
 		unsigned int getMinorVersion() const { return spvgentwo::getMinorVersion(m_spvVersion); }

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -1214,8 +1214,14 @@ spvgentwo::Instruction* spvgentwo::Instruction::opSelect(Instruction* _pCondBool
 
 	if (trueType == nullptr || falseType == nullptr || condType == nullptr) return error();
 
-	if (*trueType == *falseType && condType->isScalarOrVectorOf(spv::Op::OpTypeBool) && 
-		condType->getScalarOrVectorLength() == trueType->getScalarOrVectorLength())
+	if(*trueType != *falseType)
+	{
+		getModule()->logError("Object argument types of opSelect are not identical");
+		return error();
+	}
+
+	if (condType->isBool() || // scalar, ignore object dimensions
+		(condType->isVectorOfBool() && trueType->isVector() && condType->getVectorComponentCount() == trueType->getVectorComponentCount()))
 	{
 		// Before version1.4, results are only computed per component.
 		// Before version1.4, Result Type must be a pointer, scalar, or vector. Starting with version 1.4, Result Type can additionally be a composite type other than a vector.

--- a/lib/source/Instruction.cpp
+++ b/lib/source/Instruction.cpp
@@ -1230,7 +1230,7 @@ spvgentwo::Instruction* spvgentwo::Instruction::opSelect(Instruction* _pCondBool
 
 		bool pre14 = trueType->isScalar() || trueType->isVector() || trueType->isPointer();
 
-		if((trueType->isComposite() && pre14 == false) || condType->isBool() && trueType->isVector())
+		if((trueType->isComposite() && pre14 == false) || (condType->isBool() && trueType->isVector()))
 		{
 			module->ensureSpvVersion(1u, 4u);
 		}

--- a/lib/source/Module.cpp
+++ b/lib/source/Module.cpp
@@ -199,6 +199,15 @@ void spvgentwo::Module::reset()
 	m_Lines.clear();
 }
 
+void spvgentwo::Module::ensureSpvVersion(unsigned char _major, unsigned char _minor)
+{
+	auto newVersion = makeVersion(_major, _minor);
+	if (newVersion > m_spvVersion)
+	{
+		m_spvVersion = newVersion;
+	}
+}
+
 spvgentwo::Function& spvgentwo::Module::addFunction()
 {
 	return m_Functions.emplace_back(this);
@@ -693,14 +702,17 @@ spvgentwo::spv::Id spvgentwo::Module::assignIDs(const Grammar* _pGrammar)
 			{
 				for (const spv::Capability& c : info->capabilities)
 				{
+					logDebug("Adding SPIR-V capability %u", static_cast<unsigned>(c)); // TODO: get name of capability
 					addCapability(c);
 				}
 				for (const spv::Extension& e : info->extensions)
 				{
+					logDebug("Adding SPIR-V extension %s for use of %s", spv::ExtensionNames[static_cast<unsigned>(e)], info->name);
 					addExtension(e);
 				}
 				if (info->version > maxVersion)
 				{
+					logDebug("Bumped SPIR-V version from %u to %u for use of %s", maxVersion, info->version, info->name);
 					maxVersion = info->version;
 				}
 			}

--- a/lib/source/Module.cpp
+++ b/lib/source/Module.cpp
@@ -683,7 +683,7 @@ void spvgentwo::Module::setMemoryModel(const spv::AddressingModel _addressModel,
 spvgentwo::spv::Id spvgentwo::Module::assignIDs(const Grammar* _pGrammar)
 {
 	unsigned int maxId = 0u;
-	unsigned int maxVersion = makeVersion(1u, 0u);
+	unsigned int maxVersion = m_spvVersion;
 
 	iterateInstructions([&maxId, &maxVersion, _pGrammar, this](Instruction& instr)
 	{


### PR DESCRIPTION
The [specification](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpSelect) suggests the condition can be a scalar bool, but spirv-val seems to disagree, at least when the object types a vectors.

```
        %167 = OpVectorShuffle %v4float %165 %166 0 1 1 2
        %168 = OpUndef %v3float
        %169 = OpVectorShuffle %v4float %168 %166 1 2 3 0
        %170 = OpLoad %8 %u_normalMap None
        %171 = OpImageSampleExplicitLod %v4float %170 %44 Lod %float_0_5
        %172 = OpImageSampleImplicitLod %v4float %170 %44
        %173 = OpImageDrefGather %v4float %170 %44 %float_0_5
        %174 = OpLoad %10 %u_someImage None
        %175 = OpImageFetch %v4float %174 %47
        %176 = OpAccessChain %_ptr_Uniform_float %u_Position %uint_0
        %177 = OpLoad %float %176 None
        %178 = OpFOrdEqual %bool %177 %88
>>> %179 = OpSelect %v4float %178 %167 %169
        %180 = OpSelect %v4float %53 %167 %169
```

error: line 204: Expected vector sizes of Result Type and the condition to be equal: Select
  %179 = OpSelect %v4float %178 %167 %169 (seems like the condition cant be scalar when object type is a vector)