### PR TITLE
Fix importing referenced OpExtInstImport instructions

### DIFF
--- a/common/source/LinkerHelper.cpp
+++ b/common/source/LinkerHelper.cpp
@@ -313,9 +313,9 @@ namespace
 				{
 					for (const auto& [name, instr] : lib->getModule()->getExtInstrImports())
 					{
-						if (&instr == lib && module->getExtensionInstructionImport(name.c_str()) == nullptr)
+						if (&instr == lib) // this is the extension we are looking for
 						{
-							cInstr = module->addExtensionInstructionImport(name.c_str());
+							cInstr = module->addExtensionInstructionImport(name.c_str()); // unique add / lookup
 							break;
 						}
 					}


### PR DESCRIPTION
fix unnecessary check for extension (we always want to return/reuse the extension instruction)