### PR TITLE
Treat OpSpecConst similar to variables

### DIFF
--- a/common/source/LinkerHelper.cpp
+++ b/common/source/LinkerHelper.cpp
@@ -250,7 +250,7 @@ namespace
 				cInstr = *ppTarget;
 				cached = true;
 			}
-			else if (lib->isSpecOrConstant())
+			else if (lib->isConstant())
 			{
 				if (const Constant* c = lib->getConstant(); c != nullptr && (_options & LinkerOptionBits::ImportMissingConstants))
 				{
@@ -258,7 +258,21 @@ namespace
 				}
 				else
 				{
-					operandError("Op(Spec)Constant", "Use \'ImportMissingConstants\'.");
+					operandError("OpConstant", "Use \'ImportMissingConstants\'.");
+					reported = true;
+				}
+			}
+			else if ( lib->isSpecConstant() )
+			{
+				if (_options & LinkerOptionBits::ImportMissingConstants)
+				{
+					cInstr = module->addConstantInstr();
+					if ( transferInstruction(lib, cInstr, _cache, _options) == false ) return false;
+					cached = true;
+				}
+				else
+				{
+					operandError("OpSpecConstant", "Use \'ImportMissingConstants\'.");
 					reported = true;
 				}
 			}

--- a/common/source/ReflectionHelper.cpp
+++ b/common/source/ReflectionHelper.cpp
@@ -24,9 +24,9 @@ bool spvgentwo::ReflectionHelper::getLocalSize(const Module& _module, unsigned i
 					if (instr == nullptr || instr->isSpecOrConstant() == false)
 						return 0u;
 
-					if(const Constant* c = instr->getConstant(); c != nullptr && c->getData().empty() == false && c->getType().isInt())
+					if(auto it = instr->getFirstActualOperand(); it->isLiteral() )
 					{
-						return c->getData().front();
+						return it->literal;
 					}
 
 					return 0u;

--- a/lib/include/spvgentwo/Module.h
+++ b/lib/include/spvgentwo/Module.h
@@ -181,7 +181,7 @@ namespace spvgentwo
 		const Constant* getConstantInfo(const Instruction* _pConstantInstr);
 
 		template <class T>
-		Instruction* constant(const T& _value, const bool _spec = false, const char* _pName = nullptr);
+		Instruction* constant(const T& _value, bool _spec = false, const char* _pName = nullptr);
 
 		template <class T>
 		Instruction* specConstant(const T& _value, const char* _pName = nullptr) { return constant<T>(_value, true, _pName); }

--- a/lib/include/spvgentwo/ModuleTemplate.inl
+++ b/lib/include/spvgentwo/ModuleTemplate.inl
@@ -83,7 +83,7 @@ namespace spvgentwo
 	}
 
 	template<class T>
-	inline Instruction* Module::constant(const T& _value, const bool _spec, const char* _pName)
+	inline Instruction* Module::constant(const T& _value, bool _spec, const char* _pName)
 	{
 		Constant dummy(m_pAllocator);
 		return addConstant(dummy.make<T>(_value, _spec), _pName);

--- a/test/source/Constants.cpp
+++ b/test/source/Constants.cpp
@@ -51,7 +51,7 @@ spvgentwo::Module test::constants(spvgentwo::IAllocator* _pAllocator, spvgentwo:
 		Instruction* nullptrconst = module.constant(const_null_t<unsigned int*>{});
 	}
 
-	// specialization constatant
+	// specialization constants
 	{
 		// integer specialization constant with value 42
 		Instruction* intconst = module.constant(42u, true);

--- a/test/source/Linkage.cpp
+++ b/test/source/Linkage.cpp
@@ -90,7 +90,7 @@ spvgentwo::Module test::linkageLibB(spvgentwo::IAllocator* _pAllocator, spvgentw
 		Instruction* x = funcPolynomial.getParameter(0);
 		module.addName(x, "x");
 
-		Instruction* loopCount = module.constant(8u, "count");
+		Instruction* loopCount = module.constant(8u, true, "count");
 		Instruction* varI = funcPolynomial.variable(0u, "i");
 		Instruction* varSum = funcPolynomial.variable<float>(0.f, "s");
 		Instruction* fltPtr = module.type<float*>("float*", spv::StorageClass::Uniform);


### PR DESCRIPTION
module.addConstant() returns a new pointer for each OpSpecConstantXXX instruction unlike OpConstantXXX which will return the same pointer for constant of identical data